### PR TITLE
Error pagina

### DIFF
--- a/public/src/global.css
+++ b/public/src/global.css
@@ -1,3 +1,14 @@
+h1 {
+    margin: 0 0 1rem 0;
+    font-size: clamp(3.1rem, 13vw, 3.5rem);
+    line-height: 110%;
+}
+
+p {
+    margin: 0 0 2.5rem 0;
+    font-size: 1.4rem;
+}
+
 .connected {
     display: block !important;
     animation: connected .5s forwards;
@@ -11,6 +22,7 @@
     from {
         scale: 0;
     }
+
     to {
         scale: 1;
     }
@@ -20,6 +32,7 @@
     from {
         opacity: 1;
     }
+
     to {
         opacity: .1;
     }

--- a/public/src/lib/components/atoms/button.svelte
+++ b/public/src/lib/components/atoms/button.svelte
@@ -6,7 +6,7 @@
 
 <style>
     a {
-        all: unset;
+        text-decoration: none;
         padding: .5rem 1rem;
         background-color: #008649;
         color: white;

--- a/public/src/lib/components/atoms/button.svelte
+++ b/public/src/lib/components/atoms/button.svelte
@@ -1,16 +1,17 @@
 <script>
-    export let content
+    export let url, content
 </script>
 
-<button>{content}</button>
+<a href={url}>{content}</a>
 
 <style>
-    button {
+    a {
         all: unset;
         padding: .5rem 1rem;
         background-color: #008649;
         color: white;
         border-radius: 4px;
         font-size: 1.1rem;
+        cursor: pointer;
     }
 </style>

--- a/public/src/lib/components/atoms/link.svelte
+++ b/public/src/lib/components/atoms/link.svelte
@@ -1,0 +1,13 @@
+<script>
+    export let url, content
+</script>
+
+<a href={url}>{content}</a>
+
+<style>
+	a {
+		all: unset;
+		padding: 0.5rem 1rem;
+		cursor: pointer;
+	}
+</style>

--- a/public/src/lib/components/atoms/link.svelte
+++ b/public/src/lib/components/atoms/link.svelte
@@ -6,8 +6,9 @@
 
 <style>
 	a {
-		all: unset;
+		text-decoration: none;
 		padding: 0.5rem 1rem;
 		cursor: pointer;
+		color: #202020;
 	}
 </style>

--- a/public/src/lib/components/organisms/errorpagina.svelte
+++ b/public/src/lib/components/organisms/errorpagina.svelte
@@ -1,0 +1,46 @@
+<script>
+	import { UnderlinedWord, Button, Link } from '$lib/index.js';
+</script>
+
+<div>
+	<section>
+		<h1><span>Oeps!</span> Er is iets mis gegaan</h1>
+		<p>Helaas, we konden de pagina die je zocht niet vinden.</p>
+		<Button url={'/'} content={'Terug naar home'} />
+		<Link url={'mailto:info@werktijden.nl'} content={'Neem contact op →'} />
+	</section>
+</div>
+
+<style>
+	div {
+		display: flex;
+		justify-content: center;
+		max-width: 85rem;
+		margin-inline: auto;
+		margin-top: 6rem;
+		font-family:
+			system-ui,
+			-apple-system,
+			BlinkMacSystemFont,
+			'Segoe UI',
+			Roboto,
+			Oxygen,
+			Ubuntu,
+			Cantarell,
+			'Open Sans',
+			'Helvetica Neue',
+			sans-serif;
+		font-weight: 500;
+	}
+
+	section {
+		text-align: center;
+		margin: 0.5rem;
+		margin-top: 5rem;
+		
+	}
+
+	span {
+		color: #008649;
+	}
+</style>

--- a/public/src/lib/components/organisms/errorpagina.svelte
+++ b/public/src/lib/components/organisms/errorpagina.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { UnderlinedWord, Button, Link } from '$lib/index.js';
+	import { Button, Link } from '$lib/index.js';
 </script>
 
 <div>

--- a/public/src/lib/index.js
+++ b/public/src/lib/index.js
@@ -6,11 +6,13 @@ export { default as Button } from '$lib/components/atoms/button.svelte';
 export { default as StepBlock } from '$lib/components/atoms/step-block.svelte';
 export { default as StepHeading } from '$lib/components/atoms/step-heading.svelte';
 export { default as StepText } from '$lib/components/atoms/step-text.svelte';
+export { default as Link } from '$lib/components/atoms/link.svelte';
 
 export { default as Step } from '$lib/components/molecules/step.svelte';
 export { default as Iphone } from '$lib/components/molecules/iphone.svelte';
 
 export { default as KoppelMobile } from '$lib/components/organisms/koppelmobile.svelte';
+export { default as ErrorPagina } from '$lib/components/organisms/errorpagina.svelte';
 
 export { default as Weer1 } from '$lib/components/widgets/weer-1.svelte';
 export { default as Analogeklok1 } from '$lib/components/widgets/analogeklok-1.svelte';

--- a/public/src/routes/+error.svelte
+++ b/public/src/routes/+error.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { ErrorPagina } from '$lib/index.js';
+</script>
+
+<svelte:head>
+	<title>LiveWidgets Werktijden - Error</title>
+	<meta name="description" content="Er is wat fout gegaan tijdens het navigeren van Werktijden.nl" />
+</svelte:head>
+
+<ErrorPagina />

--- a/public/src/routes/+page.svelte
+++ b/public/src/routes/+page.svelte
@@ -77,15 +77,6 @@
 		max-width: 30rem;
 		color: #202020;
 	}
-	h1 {
-		margin: 0 0 1rem 0;
-		font-size: clamp(3.1rem, 13vw, 3.5rem);
-		line-height: 110%;
-	}
-	p {
-		margin: 0 0 2.5rem 0;
-		font-size: 1.4rem;
-	}
 
 	@media screen and (max-width: 1221px) {
 		div {


### PR DESCRIPTION
[#6 Error pagina](https://github.com/WesleySchorel/werktijden-smartboard/issues/6)

Ik heb een errorpagina toevoegd als fallback in svelte, zodat de gebruiker op een pagina komt waarbij je terug kan navigeren naar home of contact kan opnemen voor vragen. 

Wanneer een gebruik een onjuiste url invoert of er mocht een fout optreden tijdens het navigeren van de website moet de gebruiker feedback ontvangen wat de volgende stap kan zijn. Hiervoor zullen we een error pagina toevoegen.

## **Quality Assurance**

**Is het component responsive en voldoet het aan de huisstijl?**
- [x] Alles werkt op Desktop
- [x] Alles werkt op Tablet
- [x] Alles werkt op Mobile


**Voldoet het component aan de afgesproken coding standards?** 
- [x] Web standaarden
- [x] Semantische 
- [x] Atomic design
- [x] Best practices
- [x] Imports bovenaan
- [x] Styling onderaan


**Is het component toegankelijk?** 
- [x] Lighthouse toegankelijk test
- [x] Handmatige test


**Is het component performant?**
- [x] Lighthouse performance test


### Lighthouse test:
De scores van de lighthouse test komen goed terug. Volgens de lighthouse test staat de SEO op 80, maar omdat dit een errorpagina is waarbij SEO niet van belang is de score zoals gewenst.

![image](https://github.com/WesleySchorel/werktijden-smartboard/assets/112857487/d43abf3b-e0fc-4fe7-9583-bfd9a0174e26)



## Preview:

![image](https://github.com/WesleySchorel/werktijden-smartboard/assets/112857487/0af2eae4-f6e3-4c60-83cc-484d45b350c0)



## Planning:
De error pagina is momenteel functioneel zoals gewenst. Om de error pagina op te vrogelijken staat er nog creative coding op de planning. Welke extra content er op de error pagina komt moet ik nog invullen op een later moment.


### "Even error pages have a story to tell; sometimes they're just waiting for someone to read between the lines." 
~ Unknown

